### PR TITLE
v0.0.6, with a ton of fixes

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+   "trailingComma": "all",
+   "semi": false,
+   "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
       "type": "object",
       "title": "Formatter configuration",
       "properties": {
+        "ocaml-reason-format.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether or not this plugin should be used for formatting"
+        },
         "ocaml-reason-format.ocamlformat": {
           "type": "string",
           "default": "ocamlformat",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "onLanguage:ocaml",
     "onLanguage:reason"
   ],
-  "main": "./out/extension.js",
+  "main": "./out/bundle.js",
   "contributes": {
     "languages": [
       {
@@ -61,16 +61,19 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "yarn run compile",
-    "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./",
+    "vscode:prepublish": "npm run esbuild-base -- --minify",
+    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/bundle.js --external:vscode --format=cjs --platform=node",
+    "esbuild": "npm run esbuild-base -- --sourcemap",
+    "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "yarn run compile && node ./node_modules/vscode/bin/test"
+    "test-compile": "tsc -p ./",
+    "test": "yarn run test-compile && node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",
     "@types/node": "^10.12.21",
     "@types/uuid": "^8.3.3",
+    "esbuild": "^0.14.27",
     "tslint": "^5.12.1",
     "typescript": "^3.3.1",
     "uuid": "^8.3.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,9 +37,6 @@ function getFullTextRange(textEditor: vscode.TextEditor) {
 log.appendLine(`Loading extension...`)
 
 export async function activate(context: vscode.ExtensionContext) {
-  const configuration = vscode.workspace.getConfiguration('ocaml-reason-format')
-  const rootPath = vscode.workspace.rootPath || ''
-
   log.appendLine(`Activating extension...`)
   const ourTmpDir = await prepareTmpDir()
   log.appendLine(`Using tmpDir ${ourTmpDir}`)
@@ -50,6 +47,11 @@ export async function activate(context: vscode.ExtensionContext) {
       async provideDocumentFormattingEdits(
         document: vscode.TextDocument,
       ): Promise<vscode.TextEdit[]> {
+        const configuration = vscode.workspace.getConfiguration(
+          'ocaml-reason-format',
+        )
+        const rootPath = vscode.workspace.rootPath || ''
+
         const formatterPath = configuration.get<string | undefined>(
           'ocamlformat',
         )
@@ -77,7 +79,6 @@ export async function activate(context: vscode.ExtensionContext) {
             throw e
           }
 
-
           // TODO: Replace this with `document.getText()`, lest it break Format On Save:
           //   <https://github.com/microsoft/vscode/issues/90273#issuecomment-584087026>
           const formattedText = await readFile(tmpFilePath, 'utf8')
@@ -97,6 +98,11 @@ export async function activate(context: vscode.ExtensionContext) {
       async provideDocumentFormattingEdits(
         document: vscode.TextDocument,
       ): Promise<vscode.TextEdit[]> {
+        const configuration = vscode.workspace.getConfiguration(
+          'ocaml-reason-format',
+        )
+        const rootPath = vscode.workspace.rootPath || ''
+
         const formatterPath = configuration.get<string | undefined>('refmt')
         const formatter = formatterPath
           ? path.resolve(rootPath, formatterPath)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,8 @@
-import * as path from 'path'
-import * as vscode from 'vscode'
-import * as process from 'child_process'
 import * as fs from 'fs'
+import * as path from 'path'
+import * as process from 'child_process'
 import * as uuid from 'uuid'
+import * as vscode from 'vscode'
 
 const tmpDir = '/tmp/vscode-ocaml-reason-format'
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
   log.appendLine(`Activating extension...`)
 
   const disposable1 = vscode.languages.registerDocumentFormattingEditProvider(
-    'ocaml',
+    { language: 'ocaml', scheme: 'file' },
     {
       async provideDocumentFormattingEdits(
         document: vscode.TextDocument,
@@ -82,7 +82,7 @@ export function activate(context: vscode.ExtensionContext) {
   )
 
   const disposable2 = vscode.languages.registerDocumentFormattingEditProvider(
-    'reason',
+    { language: 'reason', scheme: 'file' },
     {
       async provideDocumentFormattingEdits(
         document: vscode.TextDocument,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,13 +2,13 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 import * as process from 'child_process'
 import * as fs from 'fs'
-import * as uuid from 'uuid';
+import * as uuid from 'uuid'
 
-const tmpDir = "/tmp/vscode-ocaml-reason-format"
+const tmpDir = '/tmp/vscode-ocaml-reason-format'
 
 function prepareTmpDir() {
-  if (!fs.existsSync(tmpDir)){
-    fs.mkdirSync(tmpDir, { recursive: true });
+  if (!fs.existsSync(tmpDir)) {
+    fs.mkdirSync(tmpDir, { recursive: true })
   }
 }
 
@@ -20,18 +20,22 @@ function getFullTextRange(textEditor: vscode.TextEditor) {
     0,
     firstLine.range.start.character,
     textEditor.document.lineCount - 1,
-    lastLine.range.end.character
+    lastLine.range.end.character,
   )
 }
 
 export function activate(context: vscode.ExtensionContext) {
-  const configuration = vscode.workspace.getConfiguration("ocaml-reason-format")
-  const rootPath = vscode.workspace.rootPath || "";
+  const configuration = vscode.workspace.getConfiguration('ocaml-reason-format')
+  const rootPath = vscode.workspace.rootPath || ''
 
   vscode.languages.registerDocumentFormattingEditProvider('ocaml', {
-    provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
-      const formatterPath = configuration.get<string | undefined>("ocamlformat")
-      const formatter = formatterPath ? path.resolve(rootPath, formatterPath) : "ocamlformat"
+    provideDocumentFormattingEdits(
+      document: vscode.TextDocument,
+    ): vscode.TextEdit[] {
+      const formatterPath = configuration.get<string | undefined>('ocamlformat')
+      const formatter = formatterPath
+        ? path.resolve(rootPath, formatterPath)
+        : 'ocamlformat'
       const textEditor = vscode.window.activeTextEditor
 
       if (textEditor) {
@@ -40,22 +44,28 @@ export function activate(context: vscode.ExtensionContext) {
         const tmpFilePath = `${path.join(tmpDir, uuid.v4())}${extName}`
 
         prepareTmpDir()
-        process.execSync(`cd ${rootPath} && ${formatter} ${filePath} > ${tmpFilePath}`)
+        process.execSync(
+          `cd ${rootPath} && ${formatter} ${filePath} > ${tmpFilePath}`,
+        )
 
-        const formattedText = fs.readFileSync(tmpFilePath, 'utf8');
+        const formattedText = fs.readFileSync(tmpFilePath, 'utf8')
         const textRange = getFullTextRange(textEditor)
 
         return [vscode.TextEdit.replace(textRange, formattedText)]
       } else {
         return []
       }
-    }
+    },
   })
 
   vscode.languages.registerDocumentFormattingEditProvider('reason', {
-    provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
-      const formatterPath = configuration.get<string | undefined>("refmt")
-      const formatter = formatterPath ? path.resolve(rootPath, formatterPath) : "refmt"
+    provideDocumentFormattingEdits(
+      document: vscode.TextDocument,
+    ): vscode.TextEdit[] {
+      const formatterPath = configuration.get<string | undefined>('refmt')
+      const formatter = formatterPath
+        ? path.resolve(rootPath, formatterPath)
+        : 'refmt'
       const textEditor = vscode.window.activeTextEditor
 
       if (textEditor) {
@@ -67,7 +77,7 @@ export function activate(context: vscode.ExtensionContext) {
         fs.copyFileSync(filePath, tmpFilePath)
         process.execSync(`${formatter} ${tmpFilePath}`).toString()
 
-        const formattedText = fs.readFileSync(tmpFilePath, 'utf8');
+        const formattedText = fs.readFileSync(tmpFilePath, 'utf8')
         const textRange = getFullTextRange(textEditor)
 
         fs.unlinkSync(tmpFilePath)
@@ -76,7 +86,7 @@ export function activate(context: vscode.ExtensionContext) {
       } else {
         return []
       }
-    }
+    },
   })
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
           const command = `cd ${rootPath} && ${formatter} ${filePath} > ${tmpFilePath}`
           log.appendLine('`' + command + `'`)
-          await exec(command)
+          try {
+            await exec(command)
+          } catch (e) {
+            log.appendLine(e.stderr)
+            vscode.window.showErrorMessage(e.stderr)
+            throw e
+          }
+
 
           // TODO: Replace this with `document.getText()`, lest it break Format On Save:
           //   <https://github.com/microsoft/vscode/issues/90273#issuecomment-584087026>
@@ -109,7 +116,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
           const command = `${formatter} ${tmpFilePath}`
           log.appendLine('`' + command + `'`)
-          await exec(command)
+          try {
+            await exec(command)
+          } catch (e) {
+            log.appendLine(e.stderr)
+            vscode.window.showErrorMessage(e.stderr)
+            throw e
+          }
 
           // TODO: Replace this with `document.getText()`, lest it break Format On Save:
           //   <https://github.com/microsoft/vscode/issues/90273#issuecomment-584087026>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,10 +60,7 @@ function registerOcamlFormatter(ctx: vscode.ExtensionContext, tmpDir: string) {
 
           const rootPath = vscode.workspace.rootPath || ''
 
-          const formatterPath = config.get<string | undefined>('ocamlformat')
-          const formatter = formatterPath
-            ? path.resolve(rootPath, formatterPath)
-            : 'ocamlformat'
+          const formatter = config.get<string | undefined>('ocamlformat')
           const textEditor = vscode.window.activeTextEditor
 
           if (textEditor) {
@@ -75,7 +72,7 @@ function registerOcamlFormatter(ctx: vscode.ExtensionContext, tmpDir: string) {
 
             await prepareTmpDir()
 
-            const command = `cd ${rootPath} && ${formatter} ${filePath} > ${tmpFilePath}`
+            const command = `cd ${rootPath} &&\n  ${formatter} ${filePath} > ${tmpFilePath}`
             log.appendLine('`' + command + `'`)
             try {
               await exec(command)
@@ -119,10 +116,7 @@ function registerReasonFormatter(ctx: vscode.ExtensionContext, tmpDir: string) {
 
           const rootPath = vscode.workspace.rootPath || ''
 
-          const formatterPath = config.get<string | undefined>('refmt')
-          const formatter = formatterPath
-            ? path.resolve(rootPath, formatterPath)
-            : 'refmt'
+          const formatter = config.get<string | undefined>('refmt')
           const textEditor = vscode.window.activeTextEditor
 
           if (textEditor) {
@@ -136,7 +130,7 @@ function registerReasonFormatter(ctx: vscode.ExtensionContext, tmpDir: string) {
             log.appendLine(`Copying '${filePath}' to '${tmpFilePath}'...`)
             await copyFile(filePath, tmpFilePath)
 
-            const command = `${formatter} ${tmpFilePath}`
+            const command = `cd ${rootPath} &&\n  ${formatter} ${tmpFilePath}`
             log.appendLine('`' + command + `'`)
             try {
               await exec(command)

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,6 +178,132 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
+esbuild-android-64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.27.tgz#b868bbd9955a92309c69df628d8dd1945478b45c"
+  integrity sha512-LuEd4uPuj/16Y8j6kqy3Z2E9vNY9logfq8Tq+oTE2PZVuNs3M1kj5Qd4O95ee66yDGb3isaOCV7sOLDwtMfGaQ==
+
+esbuild-android-arm64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.27.tgz#e7d6430555e8e9c505fd87266bbc709f25f1825c"
+  integrity sha512-E8Ktwwa6vX8q7QeJmg8yepBYXaee50OdQS3BFtEHKrzbV45H4foMOeEE7uqdjGQZFBap5VAqo7pvjlyA92wznQ==
+
+esbuild-darwin-64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.27.tgz#4dc7484127564e89b4445c0a560a3cb50b3d68e1"
+  integrity sha512-czw/kXl/1ZdenPWfw9jDc5iuIYxqUxgQ/Q+hRd4/3udyGGVI31r29LCViN2bAJgGvQkqyLGVcG03PJPEXQ5i2g==
+
+esbuild-darwin-arm64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.27.tgz#469e59c665f84a8ed323166624c5e7b9b2d22ac1"
+  integrity sha512-BEsv2U2U4o672oV8+xpXNxN9bgqRCtddQC6WBh4YhXKDcSZcdNh7+6nS+DM2vu7qWIWNA4JbRG24LUUYXysimQ==
+
+esbuild-freebsd-64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.27.tgz#895df03bf5f87094a56c9a5815bf92e591903d70"
+  integrity sha512-7FeiFPGBo+ga+kOkDxtPmdPZdayrSzsV9pmfHxcyLKxu+3oTcajeZlOO1y9HW+t5aFZPiv7czOHM4KNd0tNwCA==
+
+esbuild-freebsd-arm64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.27.tgz#0b72a41a6b8655e9a8c5608f2ec1afdcf6958441"
+  integrity sha512-8CK3++foRZJluOWXpllG5zwAVlxtv36NpHfsbWS7TYlD8S+QruXltKlXToc/5ZNzBK++l6rvRKELu/puCLc7jA==
+
+esbuild-linux-32@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.27.tgz#43b8ba3803b0bbe7f051869c6a8bf6de1e95de28"
+  integrity sha512-qhNYIcT+EsYSBClZ5QhLzFzV5iVsP1YsITqblSaztr3+ZJUI+GoK8aXHyzKd7/CKKuK93cxEMJPpfi1dfsOfdw==
+
+esbuild-linux-64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.27.tgz#dc8072097327ecfadba1735562824ce8c05dd0bd"
+  integrity sha512-ESjck9+EsHoTaKWlFKJpPZRN26uiav5gkI16RuI8WBxUdLrrAlYuYSndxxKgEn1csd968BX/8yQZATYf/9+/qg==
+
+esbuild-linux-arm64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.27.tgz#c52b58cbe948426b1559910f521b0a3f396f10b8"
+  integrity sha512-no6Mi17eV2tHlJnqBHRLekpZ2/VYx+NfGxKcBE/2xOMYwctsanCaXxw4zapvNrGE9X38vefVXLz6YCF8b1EHiQ==
+
+esbuild-linux-arm@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.27.tgz#df869dbd67d4ee3a04b3c7273b6bd2b233e78a18"
+  integrity sha512-JnnmgUBdqLQO9hoNZQqNHFWlNpSX82vzB3rYuCJMhtkuaWQEmQz6Lec1UIxJdC38ifEghNTBsF9bbe8dFilnCw==
+
+esbuild-linux-mips64le@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.27.tgz#a2b646d9df368b01aa970a7b8968be6dd6b01d19"
+  integrity sha512-NolWP2uOvIJpbwpsDbwfeExZOY1bZNlWE/kVfkzLMsSgqeVcl5YMen/cedRe9mKnpfLli+i0uSp7N+fkKNU27A==
+
+esbuild-linux-ppc64le@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.27.tgz#9a21af766a0292578a3009c7408b8509cac7cefd"
+  integrity sha512-/7dTjDvXMdRKmsSxKXeWyonuGgblnYDn0MI1xDC7J1VQXny8k1qgNp6VmrlsawwnsymSUUiThhkJsI+rx0taNA==
+
+esbuild-linux-riscv64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.27.tgz#344a27f91568056a5903ad5841b447e00e78d740"
+  integrity sha512-D+aFiUzOJG13RhrSmZgrcFaF4UUHpqj7XSKrIiCXIj1dkIkFqdrmqMSOtSs78dOtObWiOrFCDDzB24UyeEiNGg==
+
+esbuild-linux-s390x@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.27.tgz#73a7309bd648a07ef58f069658f989a5096130db"
+  integrity sha512-CD/D4tj0U4UQjELkdNlZhQ8nDHU5rBn6NGp47Hiz0Y7/akAY5i0oGadhEIg0WCY/HYVXFb3CsSPPwaKcTOW3bg==
+
+esbuild-netbsd-64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.27.tgz#482a587cdbd18a6c264a05136596927deb46c30a"
+  integrity sha512-h3mAld69SrO1VoaMpYl3a5FNdGRE/Nqc+E8VtHOag4tyBwhCQXxtvDDOAKOUQexBGca0IuR6UayQ4ntSX5ij1Q==
+
+esbuild-openbsd-64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.27.tgz#e99f8cdc63f1628747b63edd124d53cf7796468d"
+  integrity sha512-xwSje6qIZaDHXWoPpIgvL+7fC6WeubHHv18tusLYMwL+Z6bEa4Pbfs5IWDtQdHkArtfxEkIZz77944z8MgDxGw==
+
+esbuild-sunos-64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.27.tgz#8611d825bcb8239c78d57452e83253a71942f45c"
+  integrity sha512-/nBVpWIDjYiyMhuqIqbXXsxBc58cBVH9uztAOIfWShStxq9BNBik92oPQPJ57nzWXRNKQUEFWr4Q98utDWz7jg==
+
+esbuild-windows-32@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.27.tgz#c06374206d4d92dd31d4fda299b09f51a35e82f6"
+  integrity sha512-Q9/zEjhZJ4trtWhFWIZvS/7RUzzi8rvkoaS9oiizkHTTKd8UxFwn/Mm2OywsAfYymgUYm8+y2b+BKTNEFxUekw==
+
+esbuild-windows-64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.27.tgz#756631c1d301dfc0d1a887deed2459ce4079582f"
+  integrity sha512-b3y3vTSl5aEhWHK66ngtiS/c6byLf6y/ZBvODH1YkBM+MGtVL6jN38FdHUsZasCz9gFwYs/lJMVY9u7GL6wfYg==
+
+esbuild-windows-arm64@0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.27.tgz#ad7e187193dcd18768b16065a950f4441d7173f4"
+  integrity sha512-I/reTxr6TFMcR5qbIkwRGvldMIaiBu2+MP0LlD7sOlNXrfqIl9uNjsuxFPGEG4IRomjfQ5q8WT+xlF/ySVkqKg==
+
+esbuild@^0.14.27:
+  version "0.14.27"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.27.tgz#41fe0f1b6b68b9f77cac025009bc54bb96e616f1"
+  integrity sha512-MZQt5SywZS3hA9fXnMhR22dv0oPGh6QtjJRIYbgL1AeqAoQZE+Qn5ppGYQAoHv/vq827flj4tIJ79Mrdiwk46Q==
+  optionalDependencies:
+    esbuild-android-64 "0.14.27"
+    esbuild-android-arm64 "0.14.27"
+    esbuild-darwin-64 "0.14.27"
+    esbuild-darwin-arm64 "0.14.27"
+    esbuild-freebsd-64 "0.14.27"
+    esbuild-freebsd-arm64 "0.14.27"
+    esbuild-linux-32 "0.14.27"
+    esbuild-linux-64 "0.14.27"
+    esbuild-linux-arm "0.14.27"
+    esbuild-linux-arm64 "0.14.27"
+    esbuild-linux-mips64le "0.14.27"
+    esbuild-linux-ppc64le "0.14.27"
+    esbuild-linux-riscv64 "0.14.27"
+    esbuild-linux-s390x "0.14.27"
+    esbuild-netbsd-64 "0.14.27"
+    esbuild-openbsd-64 "0.14.27"
+    esbuild-sunos-64 "0.14.27"
+    esbuild-windows-32 "0.14.27"
+    esbuild-windows-64 "0.14.27"
+    esbuild-windows-arm64 "0.14.27"
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
Yeah, yeah, I know, small pull-requests.

It's a one-file project, though, and opening a half-dozen pull-requests seemed silly.

Fixes:

- As dictated by the VScode Extension documentation, register [`vscode.Disposable`](https://code.visualstudio.com/api/references/vscode-api#Disposable)s
- Use asynchronous APIs throughout so we can return a `Promise`, which allows the user to see a progress bar as the formatting proceeds (on the off-chance that anything is slow)
- Detailed logging inside VScode, incase any of our developers have any issues when using this. (Ideally, I'd like to add some built-in `$PATH`-debugging, because that's the most likely pain-point for this — but I've already spent a solid day on this extension, and I'd like to tackle other things. Maybe I'll come back to it.)
- Correctly apply [`DocumentFilter`s](https://code.visualstudio.com/api/references/vscode-api#DocumentFilter) instead of the `DocumentSelector`, because documents residing in-memory cannot (yet) be formatted by `ocamlformat` etc. This could use a more robust fix, but that will need some thought.
- As requested by the docs, set up the formatter so it can be disabled/re-enabled *without* loading or unloading it from the installed Extensions. (I went as far as ensuring it can be dis/re-enabled multiple times in a single VScode session without a reboot!)
- Bundle dependencies (well, `uuid`) into a single file before publishing. (This, incidentally, was what was causing your registration errors.)

I dropped a note about this in the company Slack, and have a few people testing it.